### PR TITLE
Switch training scripts to PhysicsNemo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ around the airfoil using cosine spacing.
 
 ## Training
 
-Install dependencies such as `torch` and `pytorch_lightning` and run the training script:
+Install dependencies such as `torch` and `physicsnemo` and run the PhysicsNemo training script:
 
 ```bash
-python train_gno_naca4.py
+python train_physicsnemo_naca4.py
 ```


### PR DESCRIPTION
## Summary
- use PhysicsNemo instead of PyTorch Lightning
- add new PhysicsNemo-based training script
- document PhysicsNemo usage

## Testing
- `python train_gno_naca4.py --help` *(fails: No module named 'torch')*
- `python train_physicsnemo_naca4.py --help` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6850624781308322b0f2ac7afac9e160